### PR TITLE
Set error in component state

### DIFF
--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -33,6 +33,12 @@ return {
     };
   },
 
+  getInitialState: function() {
+    return {
+      isFetchingData: false
+    }
+  },
+
   componentWillMount: function() {
     this._xhrRequests = [];
 

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -150,7 +150,13 @@ return {
       }
 
       this.setState({
-        isFetchingData: false
+        isFetchingData: false,
+        dataError: {
+          url: url,
+          statusCode: xhr.status,
+          statusText: status,
+          message: err.toString()
+        }
       });
 
       console.error(url, status, err.toString());

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -132,7 +132,8 @@ return {
 
   _fetchDataFromServer: function(url, onSuccess) {
     this.setState({
-      isFetchingData: true
+      isFetchingData: true,
+      dataError: null
     });
 
     var request,

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -35,7 +35,8 @@ return {
 
   getInitialState: function() {
     return {
-      isFetchingData: false
+      isFetchingData: false,
+      dataError: null
     };
   },
 

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -159,8 +159,6 @@ return {
           message: err.toString()
         }
       });
-
-      console.error(url, status, err.toString());
     };
 
     request = $.ajax({

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -97,7 +97,7 @@ return {
      *     returns the data URL. The expected method name is "getDataUrl" and
      *     overrides the dataUrl prop when implemented
      */
-    var dataUrl = typeof(this.getDataUrl) == 'function' ?
+    var dataUrl = typeof(this.getDataUrl) === 'function' ?
                   this.getDataUrl(props) :
                   props.dataUrl;
 
@@ -146,7 +146,7 @@ return {
     onError = function(xhr, status, err) {
       if (this._ignoreXhrRequestCallbacks) {
         return;
-      };
+      }
 
       this.setState({
         isFetchingData: false

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -36,7 +36,7 @@ return {
   getInitialState: function() {
     return {
       isFetchingData: false
-    }
+    };
   },
 
   componentWillMount: function() {

--- a/tests/data-fetch-mixin.js
+++ b/tests/data-fetch-mixin.js
@@ -208,6 +208,12 @@ describe("DataFetch mixin", function() {
     expect(initialState.isFetchingData).to.equal(false);
   });
 
+  it("should set dataError to null in initial state", function() {
+    var initialState = fakeComponent.getInitialState();
+
+    expect(initialState.dataError).to.equal(null);
+  });
+
   it("should set dataError for a failed request", function() {
     fakeComponent.props.dataUrl = 'foo';
 

--- a/tests/data-fetch-mixin.js
+++ b/tests/data-fetch-mixin.js
@@ -200,5 +200,39 @@ describe("DataFetch mixin", function() {
     onError({}, 503, 'foobar');
 
     expect(fakeComponent.setState.callCount).to.equal(prevCallCount);
-  })
+  });
+
+  it("should set isFetchingData to false in initial state", function() {
+    var initialState = fakeComponent.getInitialState();
+
+    expect(initialState.isFetchingData).to.equal(false);
+  });
+
+  it("should set dataError for a failed request", function() {
+    fakeComponent.props.dataUrl = 'foo';
+
+    fakeComponent.componentWillMount();
+
+    var onError = $.ajax.args[0][0].error;
+    onError({}, 404, 'foo');
+
+    var setStateArgs = fakeComponent.setState.lastCall.args[0];
+    expect(setStateArgs.dataError.statusText).to.equal(404);
+  });
+
+  it("should reset dataError before a new request", function() {
+    fakeComponent.props.dataUrl = 'foo';
+
+    fakeComponent.componentWillMount();
+
+    // force an error
+    var onError = $.ajax.args[0][0].error;
+    onError({}, 404, 'foo');
+
+    // force a new request that triggers the reset
+    fakeComponent.componentWillMount();
+
+    var setStateArgs = fakeComponent.setState.lastCall.args[0];
+    expect(setStateArgs.dataError).to.equal(null);
+  });
 });

--- a/tests/data-fetch-mixin.js
+++ b/tests/data-fetch-mixin.js
@@ -180,7 +180,7 @@ describe("DataFetch mixin", function() {
     fakeComponent.componentWillMount();
 
     var onError = $.ajax.args[0][0].error;
-    onError(null, 503, 'foobar');
+    onError({}, 503, 'foobar');
 
     var setStateArgs = fakeComponent.setState.lastCall.args[0];
     expect(setStateArgs.isFetchingData).to.equal(false);
@@ -197,7 +197,7 @@ describe("DataFetch mixin", function() {
     var prevCallCount = fakeComponent.setState.callCount;
 
     var onError = $.ajax.args[0][0].error;
-    onError(null, 503, 'foobar');
+    onError({}, 503, 'foobar');
 
     expect(fakeComponent.setState.callCount).to.equal(prevCallCount);
   })


### PR DESCRIPTION
Closes #1 

Update component state with a `dataError` object that notifies about status code, text and message.
Bonus: set isFetchingData to false by default for components that do not have dataUrl prop