### PR TITLE
startPolling/stopPolling methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "istanbul": "^0.3.13",
     "istanbul-instrumenter-loader": "^0.1.2",
     "jscs": "^1.12.0",
-    "karma": "^0.12.31",
+    "karma": "^0.13.10",
     "karma-chai": "^0.1.0",
     "karma-cli": "0.0.4",
     "karma-coverage": "^0.2.7",
@@ -24,11 +24,11 @@
     "karma-mocha-reporter": "^1.0.2",
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-sinon-chai": "^0.3.0",
-    "karma-webpack": "^1.5.0",
+    "karma-webpack": "^1.7.0",
     "mocha": "^2.1.0",
     "sinon": "^1.12.2",
     "sinon-chai": "^2.6.0",
-    "webpack": "^1.8.0"
+    "webpack": "^1.12.2"
   },
   "main": "src/data-fetch-mixin.js",
   "scripts": {

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -30,7 +30,8 @@ module.exports = {
   getInitialState: function() {
     return {
       isFetchingData: false,
-      dataError: null
+      dataError: null,
+      isPolling: this.props.pollInterval > 0
     };
   },
 
@@ -73,6 +74,15 @@ module.exports = {
 
   stopFetching: function() {
     this._clearDataRequests();
+  },
+
+  stopPolling: function() {
+    clearInterval(this._pollInterval);
+    this._pollInterval = null;
+
+    this.setState({
+      isPolling: false
+    });
   },
 
   receiveDataFromServer: function(data) {

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -124,11 +124,6 @@ module.exports = {
     }
   },
 
-  _getDataUrl: function(props) {
-    return typeof(this.getDataUrl) === 'function' ?
-        this.getDataUrl(props) : props.dataUrl;
-  },
-
   _clearDataRequests: function() {
     // Cancel any on-going request.
     while (!_.isEmpty(this._xhrRequests)) {
@@ -137,8 +132,10 @@ module.exports = {
   },
 
   _startPolling: function(props) {
+    var url = this._getDataUrl(props);
+
     var callback = function() {
-      this._fetchDataFromServer(props.dataUrl, this.receiveDataFromServer);
+      this._fetchDataFromServer(url, this.receiveDataFromServer);
     };
 
     this._pollInterval = setInterval(callback.bind(this), props.pollInterval);
@@ -147,6 +144,11 @@ module.exports = {
   _clearPolling: function() {
     clearInterval(this._pollInterval);
     this._pollInterval = null;
+  },
+
+  _getDataUrl: function(props) {
+    return typeof(this.getDataUrl) === 'function' ?
+        this.getDataUrl(props) : props.dataUrl;
   },
 
   _fetchDataFromServer: function(url, onSuccess) {

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -85,6 +85,19 @@ module.exports = {
     });
   },
 
+  resumePolling: function() {
+    var callback = function() {
+      this._fetchDataFromServer(this.props.dataUrl, this.receiveDataFromServer);
+    };
+
+    this._pollInterval = setInterval(callback.bind(this),
+                                     this.props.pollInterval);
+
+    this.setState({
+      isPolling: true
+    });
+  },
+
   receiveDataFromServer: function(data) {
     this.setState({
       isFetchingData: false,

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -57,6 +57,7 @@ module.exports = {
 
     if (this.props.pollInterval !== nextProps.pollInterval) {
       if (this._shouldWePoll(nextProps)) {
+        this._clearPolling();
         this._startPolling(nextProps);
       } else {
         this._clearPolling();

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -49,12 +49,18 @@ module.exports = {
   componentWillReceiveProps: function(nextProps) {
     /**
      * A component can have its configuration replaced at any time so we need
-     * to fetch data again.
-     *
-     * Only fetch data if the dataUrl has changed.
+     * to fetch data again. We may also need to resume/stop polling.
      */
     if (this.props.dataUrl !== nextProps.dataUrl) {
       this._resetData(nextProps);
+    }
+
+    if (this.props.pollInterval !== nextProps.pollInterval) {
+      if (this._shouldWePoll(nextProps)) {
+        this._startPolling(nextProps);
+      } else {
+        this._clearPolling();
+      }
     }
   },
 
@@ -100,8 +106,7 @@ module.exports = {
     /**
      * Hit the dataUrl and fetch data.
      *
-     * Before starting to fetch data we reset any ongoing requests. We also
-     * reset the polling interval.
+     * Before starting to fetch data we reset any ongoing requests.
      *
      * @param {Object} props
      * @param {String} props.dataUrl The URL that will be hit for data. The URL
@@ -133,7 +138,7 @@ module.exports = {
 
   _startPolling: function(props) {
     var callback = function() {
-      this._fetchDataFromServer(props.dataUurl, this.receiveDataFromServer);
+      this._fetchDataFromServer(props.dataUrl, this.receiveDataFromServer);
     };
 
     this._pollInterval = setInterval(callback.bind(this), props.pollInterval);

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -92,6 +92,7 @@ module.exports = {
   },
 
   resumePolling: function() {
+    this._clearPolling();
     this._startPolling(this.props);
   },
 

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -30,8 +30,7 @@ module.exports = {
   getInitialState: function() {
     return {
       isFetchingData: false,
-      dataError: null,
-      isPolling: this._shouldWePoll(this.props)
+      dataError: null
     };
   },
 
@@ -80,10 +79,6 @@ module.exports = {
 
   stopPolling: function() {
     this._clearPolling();
-
-    this.setState({
-      isPolling: false
-    });
   },
 
   resumePolling: function() {
@@ -138,10 +133,6 @@ module.exports = {
     };
 
     this._pollInterval = setInterval(callback.bind(this), props.pollInterval);
-
-    this.setState({
-      isPolling: true
-    });
   },
 
   _clearPolling: function() {

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -56,11 +56,10 @@ module.exports = {
     }
 
     if (this.props.pollInterval !== nextProps.pollInterval) {
+      this._clearPolling();
+
       if (this._shouldWePoll(nextProps)) {
-        this._clearPolling();
         this._startPolling(nextProps);
-      } else {
-        this._clearPolling();
       }
     }
   },

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -40,6 +40,10 @@ module.exports = {
     // The dataUrl prop points to a source of data than will extend the initial
     // state of the component, once it will be fetched
     this._resetData(this.props);
+
+    if (this._shouldWePoll(this.props)) {
+      this._startPolling(this.props);
+    }
   },
 
   componentWillReceiveProps: function(nextProps) {

--- a/tests/data-fetch-mixin.js
+++ b/tests/data-fetch-mixin.js
@@ -282,7 +282,7 @@ describe('DataFetch mixin', function() {
         fakeComponent.componentWillMount();
       });
 
-      it('should poll the data URL', function() {
+      it('should start polling after mounting', function() {
         $.ajax.reset();
 
         var times = _.random(2, 5);
@@ -304,34 +304,26 @@ describe('DataFetch mixin', function() {
         expect($.ajax).to.not.have.been.called;
       });
 
-      describe('stopping', function() {
-        beforeEach(function() {
-          fakeComponent.stopPolling();
-        });
+      it('should stop polling when told to do so', function() {
+        $.ajax.reset();
 
-        it('should clear the timer when told to stop polling', function() {
-          $.ajax.reset();
+        fakeComponent.stopPolling();
 
-          clock.tick(fakeComponent.props.pollInterval);
+        clock.tick(fakeComponent.props.pollInterval);
 
-          expect($.ajax).to.not.have.been.called;
-        });
+        expect($.ajax).to.not.have.been.called;
+      });
 
-        describe('resuming', function() {
-          beforeEach(function() {
-            fakeComponent.resumePolling();
-          });
+      it('should start polling when told to resume', function() {
+        $.ajax.reset();
+        fakeComponent.stopPolling();
+        fakeComponent.resumePolling();
 
-          it('should start the timer when resuming polling', function() {
-            $.ajax.reset();
+        var times = _.random(2, 5);
 
-            var times = _.random(2, 5);
+        clock.tick(fakeComponent.props.pollInterval * times);
 
-            clock.tick(fakeComponent.props.pollInterval * times);
-
-            expect($.ajax.callCount).to.equal(times);
-          });
-        });
+        expect($.ajax.callCount).to.equal(times);
       });
     });
 
@@ -342,7 +334,7 @@ describe('DataFetch mixin', function() {
         fakeComponent.componentWillMount();
       });
 
-      it('should not poll the dataUrl', function() {
+      it('should not start polling after mounting', function() {
         $.ajax.reset();
 
         var times = _.random(2, 5);

--- a/tests/data-fetch-mixin.js
+++ b/tests/data-fetch-mixin.js
@@ -304,6 +304,20 @@ describe('DataFetch mixin', function() {
         expect($.ajax).to.not.have.been.called;
       });
 
+      it('should stop polling when receiving pollInterval=0', function() {
+        $.ajax.reset();
+
+        var times = _.random(2, 5),
+            oldInterval = fakeComponent.props.pollInterval;
+
+        fakeComponent.componentWillReceiveProps(
+            _.merge({}, fakeComponent.props, {pollInterval: 0}));
+
+        clock.tick(oldInterval * times);
+
+        expect($.ajax).to.not.have.been.called;
+      });
+
       it('should stop polling when told to do so', function() {
         $.ajax.reset();
 
@@ -342,6 +356,20 @@ describe('DataFetch mixin', function() {
         clock.tick(fakeComponent.props.pollInterval * times);
 
         expect($.ajax).to.not.have.been.called;
+      });
+
+      it('should start polling when receiving a poll interval', function() {
+        $.ajax.reset();
+
+        var times = _.random(2, 5),
+            interval = _.random(1000, 5000);
+
+        fakeComponent.componentWillReceiveProps(
+            _.merge({}, fakeComponent.props, {pollInterval: interval}));
+
+        clock.tick(interval * times);
+
+        expect($.ajax.callCount).to.equal(times);
       });
     });
   });

--- a/tests/data-fetch-mixin.js
+++ b/tests/data-fetch-mixin.js
@@ -331,6 +331,22 @@ describe('DataFetch mixin', function() {
           expect($.ajax).to.not.have.been.called;
         });
 
+        it('should restart polling when receiving a new poll interval',
+           function() {
+          $.ajax.reset();
+
+          var times = _.random(2, 5),
+              oldInterval = fakeComponent.props.pollInterval,
+              newInterval = oldInterval * 2;
+
+          fakeComponent.componentWillReceiveProps(
+              _.merge({}, fakeComponent.props, {pollInterval: newInterval}));
+
+          clock.tick(newInterval * times);
+
+          expect($.ajax.callCount).to.equal(times);
+        });
+
         it('should stop polling when told to do so', function() {
           $.ajax.reset();
 

--- a/tests/data-fetch-mixin.js
+++ b/tests/data-fetch-mixin.js
@@ -340,12 +340,13 @@ describe('DataFetch mixin', function() {
       });
 
       it('should poll the data URL', function() {
+        $.ajax.reset();
+
         var times = _.random(2, 5);
 
         clock.tick(fakeComponent.props.pollInterval * times);
 
-        // One for the initial request and one for each tick.
-        expect($.ajax.callCount).to.equal(1 + times);
+        expect($.ajax.callCount).to.equal(times);
       });
 
       describe('stopping', function() {
@@ -360,10 +361,33 @@ describe('DataFetch mixin', function() {
         });
 
         it('should clear the timer when told to stop polling', function() {
+          $.ajax.reset();
+
           clock.tick(fakeComponent.props.pollInterval);
 
-          // Only the initial request.
-          expect($.ajax.callCount).to.equal(1);
+          expect($.ajax).to.not.have.been.called;
+        });
+
+        describe('resuming', function() {
+          beforeEach(function() {
+            fakeComponent.resumePolling();
+          });
+
+          it('should mark polling as started when told to resume', function() {
+            expect(fakeComponent.setState).to.have.been.calledWith({
+              isPolling: true
+            });
+          });
+
+          it('should start the timer when resuming polling', function() {
+            $.ajax.reset();
+
+            var times = _.random(2, 5);
+
+            clock.tick(fakeComponent.props.pollInterval * times);
+
+            expect($.ajax.callCount).to.equal(times);
+          });
         });
       });
     });

--- a/tests/data-fetch-mixin.js
+++ b/tests/data-fetch-mixin.js
@@ -291,7 +291,7 @@ describe('DataFetch mixin', function() {
 
           clock.tick(fakeComponent.props.pollInterval * times);
 
-          expect($.ajax.callCount).to.equal(times);
+          expect($.ajax).to.have.callCount(times);
         });
 
         it('should poll the right URL', function() {
@@ -344,7 +344,7 @@ describe('DataFetch mixin', function() {
 
           clock.tick(newInterval * times);
 
-          expect($.ajax.callCount).to.equal(times);
+          expect($.ajax).to.have.callCount(times);
         });
 
         it('should stop polling when told to do so', function() {
@@ -366,7 +366,7 @@ describe('DataFetch mixin', function() {
 
           clock.tick(fakeComponent.props.pollInterval * times);
 
-          expect($.ajax.callCount).to.equal(times);
+          expect($.ajax).to.have.callCount(times);
         });
       });
 
@@ -398,7 +398,7 @@ describe('DataFetch mixin', function() {
 
           clock.tick(interval * times);
 
-          expect($.ajax.callCount).to.equal(times);
+          expect($.ajax).to.have.callCount(times);
         });
       });
     });

--- a/tests/data-fetch-mixin.js
+++ b/tests/data-fetch-mixin.js
@@ -275,24 +275,9 @@ describe('DataFetch mixin', function() {
       clock.restore();
     });
 
-    it('should mark that we\'re polling when poll interval is given',
-       function() {
-      fakeComponent.props.pollInterval = 1;
-
-      expect(fakeComponent.getInitialState().isPolling).to.be.true;
-    });
-
-    it('should mark that we\'re not polling when poll interval is not given',
-       function() {
-      fakeComponent.props.pollInterval = 0;
-
-      expect(fakeComponent.getInitialState().isPolling).to.be.false;
-    });
-
     describe('when poll interval is given', function() {
       beforeEach(function() {
         fakeComponent.props.pollInterval = _.random(1000, 5000);
-        fakeComponent.state.isPolling = true;
 
         fakeComponent.componentWillMount();
       });
@@ -324,12 +309,6 @@ describe('DataFetch mixin', function() {
           fakeComponent.stopPolling();
         });
 
-        it('should mark polling as stopped when told to stop', function() {
-          expect(fakeComponent.setState).to.have.been.calledWith({
-            isPolling: false
-          });
-        });
-
         it('should clear the timer when told to stop polling', function() {
           $.ajax.reset();
 
@@ -341,12 +320,6 @@ describe('DataFetch mixin', function() {
         describe('resuming', function() {
           beforeEach(function() {
             fakeComponent.resumePolling();
-          });
-
-          it('should mark polling as started when told to resume', function() {
-            expect(fakeComponent.setState).to.have.been.calledWith({
-              isPolling: true
-            });
           });
 
           it('should start the timer when resuming polling', function() {
@@ -365,7 +338,6 @@ describe('DataFetch mixin', function() {
     describe('when poll interval is not given', function() {
       beforeEach(function() {
         fakeComponent.props.pollInterval = 0;
-        fakeComponent.state.isPolling = false;
 
         fakeComponent.componentWillMount();
       });

--- a/tests/data-fetch-mixin.js
+++ b/tests/data-fetch-mixin.js
@@ -368,6 +368,20 @@ describe('DataFetch mixin', function() {
 
           expect($.ajax).to.have.callCount(times);
         });
+
+        it('should only poll once if told to resume multiple times',
+           function() {
+          $.ajax.reset();
+          fakeComponent.stopPolling();
+
+          _.times(_.random(2, 5), fakeComponent.resumePolling, fakeComponent);
+
+          var times = _.random(2, 5);
+
+          clock.tick(fakeComponent.props.pollInterval * times);
+
+          expect($.ajax).to.have.callCount(times);
+        });
       });
 
       describe('when poll interval is not given', function() {


### PR DESCRIPTION
## Need

```gherkin
As a developer
I want data fetching and polling to be controlled separately
Because orthogonality rules!
```


## Deliverables

- [ ] 
```gherkin
Given I have a component that implements the `DataFetch` mixin
And the component receives `pollInterval` set to a positive number
When I render the component
Then the polling is `on`.
```

- [ ] 
```gherkin
Given I have a component that implements the `DataFetch` mixin
And the component receives `pollInterval` set to a positive number
And the component is rendered
When I call the `stopPolling` method on the component
Then the polling is `off`.
````

- [ ] 
```gherkin
Given I have a component that implements the `DataFetch` mixin
And the component receives `pollInterval` set to a positive number
And the component is rendered
And I call the `stopPolling` method on the component
When I call the `startPolling` method on the component
Then the polling is `on`.
````

- [ ] 
```gherkin
Given I have a component that implements the `DataFetch` mixin
And the component receives `pollInterval` set to `0`
And the component is rendered
When the component receives `pollInterval` set to a positive number
Then the polling is `on`.
````

- [ ] 
```gherkin
Given I have a component that implements the `DataFetch` mixin
And the component receives `pollInterval` set to a positive number
And the the component is rendered
And I call the `stopPolling` method on the component
When the component receives `pollInterval` set to a positive number
Then the polling is `off`.
````

- [ ] 
```gherkin
Given I have a component that implements the `DataFetch` mixin
And the component receives `pollInterval` set to a positive number
And the the component is rendered
When the component receives `pollInterval` set to `0`
Then the polling is `off`.
````


## Solution

Separate the polling logic from the fetching logic. `startPolling` will [set the interval](https://github.com/skidding/react-data-fetch/blob/1dbf18471f246815f43034709e12942e6e2135bb/src/data-fetch-mixin.js#L115-L116) and `stopPolling` will [clear it](https://github.com/skidding/react-data-fetch/blob/1dbf18471f246815f43034709e12942e6e2135bb/src/data-fetch-mixin.js#L128-L129). Both will check if there's actually a `pollInterval` prop set.

Polling will be started on `WillMount` and `WillReceiveProps` and will be stopped on `WillUnmount` and `WillReceiveProps`.


#### TODO

- [x] tests
- [ ] implementation
