### PR TITLE
Send cross-domain cookies

### DIFF
--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -191,8 +191,8 @@ module.exports = function() {
 
       request = $.ajax({
         url: url,
-        // Even though not recommended, some $.ajaxSettings might default to POST
-        // requests. See http://api.jquery.com/jquery.ajaxsetup/
+        // Even though not recommended, some $.ajaxSettings might default to
+        // POST requests. See http://api.jquery.com/jquery.ajaxsetup/
         type: 'GET',
         dataType: 'json',
         complete: onComplete.bind(this),

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -19,9 +19,19 @@ var _ = require('lodash'),
  */
 
 /**
+ * @param {Object} [options]
+ * @param {Bool} [options.crossDomain=false] If `true`, the requests will
+ *     contain the cookies set for the other domain.
+ *
  * @returns {DataFetchMixin}
  */
-module.exports = function() {
+module.exports = function(options) {
+  options = options || {};
+
+  _.defaults(options, {
+    crossDomain: false
+  });
+
   return {
     getDefaultProps: function() {
       return {
@@ -195,6 +205,9 @@ module.exports = function() {
         // POST requests. See http://api.jquery.com/jquery.ajaxsetup/
         type: 'GET',
         dataType: 'json',
+        xhrFields: {
+          withCredentials: options.crossDomain
+        },
         complete: onComplete.bind(this),
         success: onSuccess,
         error: onError.bind(this)

--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -1,206 +1,210 @@
 var _ = require('lodash'),
     $ = require('jquery');
 
-module.exports = {
-  /**
-   * Bare functionality for fetching server-side JSON data inside a React
-   * component.
-   *
-   * Props:
-   *   - dataUrl: A URL to fetch data from. Once data is received it will be
-   *              set inside the component's state, under the data key, and
-   *              will cause a reactive re-render.
-   *   - pollInterval: An interval in milliseconds for polling the data URL.
-   *                   Defaults to 0, which means no polling.
-   *
-   * Context methods:
-   *  - getDataUrl: The data URL can be generated dynamically by composing it
-   *                using other props, inside a custom method that receives
-   *                the next props as arguments and returns the data URL. The
-   *                expected method name is "getDataUrl" and overrides the
-   *                dataUrl prop when implemented.
-   */
-  getDefaultProps: function() {
-    return {
-      // Enable polling by setting a value bigger than zero, in ms
-      pollInterval: 0
-    };
-  },
+/**
+ * Bare functionality for fetching server-side JSON data inside a React
+ * component.
+ * @typedef {Object} DataFetchMixin
+ *
+ * @param {String} dataUrl A URL to fetch data from. Once data is received it
+ *     will be set inside the component's state, under the data key, and will
+ *     cause a reactive re-render.
+ * @param {Number} [pollInterval=0] An interval in milliseconds for polling the
+ *     data URL. 0 means no polling.
+ *
+ * @param {Function} getDataUrl The data URL can be generated dynamically by
+ *     composing it using other props, inside a custom method that receives the
+ *     next props as arguments and returns the data URL. The expected method
+ *     name is "getDataUrl" and overrides the dataUrl prop when implemented.
+ */
 
-  getInitialState: function() {
-    return {
-      isFetchingData: false,
-      dataError: null
-    };
-  },
+/**
+ * @returns {DataFetchMixin}
+ */
+module.exports = function() {
+  return {
+    getDefaultProps: function() {
+      return {
+        // Enable polling by setting a value bigger than zero, in ms
+        pollInterval: 0
+      };
+    },
 
-  componentWillMount: function() {
-    this._xhrRequests = [];
+    getInitialState: function() {
+      return {
+        isFetchingData: false,
+        dataError: null
+      };
+    },
 
-    // The dataUrl prop points to a source of data than will extend the initial
-    // state of the component, once it will be fetched
-    this._resetData(this.props);
+    componentWillMount: function() {
+      this._xhrRequests = [];
 
-    if (this._shouldWePoll(this.props)) {
-      this._startPolling(this.props);
-    }
-  },
+      // The dataUrl prop points to a source of data than will extend the initial
+      // state of the component, once it will be fetched
+      this._resetData(this.props);
 
-  componentWillReceiveProps: function(nextProps) {
-    /**
-     * A component can have its configuration replaced at any time so we need
-     * to fetch data again. We may also need to reset/stop polling.
-     */
-    var dataUrlChanged = this.props.dataUrl !== nextProps.dataUrl,
-        pollIntervalChanged = this.props.pollInterval !==
-            nextProps.pollInterval;
+      if (this._shouldWePoll(this.props)) {
+        this._startPolling(this.props);
+      }
+    },
 
-    if (dataUrlChanged || pollIntervalChanged) {
+    componentWillReceiveProps: function(nextProps) {
+      /**
+       * A component can have its configuration replaced at any time so we need
+       * to fetch data again. We may also need to reset/stop polling.
+       */
+      var dataUrlChanged = this.props.dataUrl !== nextProps.dataUrl,
+          pollIntervalChanged = this.props.pollInterval !==
+              nextProps.pollInterval;
+
+      if (dataUrlChanged || pollIntervalChanged) {
+        this._clearPolling();
+
+        if (dataUrlChanged) {
+          this._resetData(nextProps);
+        }
+
+        if (this._shouldWePoll(nextProps)) {
+          this._startPolling(nextProps);
+        }
+      }
+    },
+
+    componentWillUnmount: function() {
+      // We abort any on-going requests when unmounting to make sure their
+      // callbacks will no longer be called. The error callback will still be
+      // called because of the abort action itself, so we use this flag to know
+      // to ignore it altogether from this point on
+      this._ignoreXhrRequestCallbacks = true;
+
+      this._clearDataRequests();
+
       this._clearPolling();
+    },
 
-      if (dataUrlChanged) {
-        this._resetData(nextProps);
-      }
+    refreshData: function() {
+      /**
+       * Hit the same data URL again.
+       */
+      this._resetData(this.props);
+    },
 
-      if (this._shouldWePoll(nextProps)) {
-        this._startPolling(nextProps);
-      }
-    }
-  },
+    stopFetching: function() {
+      this._clearDataRequests();
+    },
 
-  componentWillUnmount: function() {
-    // We abort any on-going requests when unmounting to make sure their
-    // callbacks will no longer be called. The error callback will still be
-    // called because of the abort action itself, so we use this flag to know
-    // to ignore it altogether from this point on
-    this._ignoreXhrRequestCallbacks = true;
+    stopPolling: function() {
+      this._clearPolling();
+    },
 
-    this._clearDataRequests();
+    resumePolling: function() {
+      this._clearPolling();
+      this._startPolling(this.props);
+    },
 
-    this._clearPolling();
-  },
-
-  refreshData: function() {
-    /**
-     * Hit the same data URL again.
-     */
-    this._resetData(this.props);
-  },
-
-  stopFetching: function() {
-    this._clearDataRequests();
-  },
-
-  stopPolling: function() {
-    this._clearPolling();
-  },
-
-  resumePolling: function() {
-    this._clearPolling();
-    this._startPolling(this.props);
-  },
-
-  receiveDataFromServer: function(data) {
-    this.setState({
-      isFetchingData: false,
-      data: data
-    });
-  },
-
-  _resetData: function(props) {
-    /**
-     * Hit the dataUrl and fetch data.
-     *
-     * Before starting to fetch data we reset any ongoing requests.
-     *
-     * @param {Object} props
-     * @param {String} props.dataUrl The URL that will be hit for data. The URL
-     *     can be generated dynamically by composing it through other props,
-     *     inside a custom method that receives the next props as arguments and
-     *     returns the data URL. The expected method name is "getDataUrl" and
-     *     overrides the dataUrl prop when implemented
-     */
-    var dataUrl = this._getDataUrl(props);
-
-    this._clearDataRequests();
-
-    if (dataUrl) {
-      this._fetchDataFromServer(dataUrl, this.receiveDataFromServer);
-    }
-  },
-
-  _clearDataRequests: function() {
-    // Cancel any on-going request.
-    while (!_.isEmpty(this._xhrRequests)) {
-      this._xhrRequests.pop().abort();
-    }
-  },
-
-  _startPolling: function(props) {
-    var url = this._getDataUrl(props);
-
-    var callback = function() {
-      this._fetchDataFromServer(url, this.receiveDataFromServer);
-    };
-
-    this._pollInterval = setInterval(callback.bind(this), props.pollInterval);
-  },
-
-  _clearPolling: function() {
-    clearInterval(this._pollInterval);
-    this._pollInterval = null;
-  },
-
-  _getDataUrl: function(props) {
-    return typeof(this.getDataUrl) === 'function' ?
-        this.getDataUrl(props) : props.dataUrl;
-  },
-
-  _fetchDataFromServer: function(url, onSuccess) {
-    this.setState({
-      isFetchingData: true,
-      dataError: null
-    });
-
-    var request,
-        onComplete,
-        onError;
-
-    onComplete = function() {
-      this._xhrRequests = _.without(this._xhrRequests, request);
-    };
-
-    onError = function(xhr, status, err) {
-      if (this._ignoreXhrRequestCallbacks) {
-        return;
-      }
-
+    receiveDataFromServer: function(data) {
       this.setState({
         isFetchingData: false,
-        dataError: {
-          url: url,
-          statusCode: xhr.status,
-          statusText: status,
-          message: err.toString()
-        }
+        data: data
       });
-    };
+    },
 
-    request = $.ajax({
-      url: url,
-      // Even though not recommended, some $.ajaxSettings might default to POST
-      // requests. See http://api.jquery.com/jquery.ajaxsetup/
-      type: 'GET',
-      dataType: 'json',
-      complete: onComplete.bind(this),
-      success: onSuccess,
-      error: onError.bind(this)
-    });
+    _resetData: function(props) {
+      /**
+       * Hit the dataUrl and fetch data.
+       *
+       * Before starting to fetch data we reset any ongoing requests.
+       *
+       * @param {Object} props
+       * @param {String} props.dataUrl The URL that will be hit for data. The URL
+       *     can be generated dynamically by composing it through other props,
+       *     inside a custom method that receives the next props as arguments and
+       *     returns the data URL. The expected method name is "getDataUrl" and
+       *     overrides the dataUrl prop when implemented
+       */
+      var dataUrl = this._getDataUrl(props);
 
-    this._xhrRequests.push(request);
-  },
+      this._clearDataRequests();
 
-  _shouldWePoll: function(props) {
-    return props.pollInterval > 0;
-  }
+      if (dataUrl) {
+        this._fetchDataFromServer(dataUrl, this.receiveDataFromServer);
+      }
+    },
+
+    _clearDataRequests: function() {
+      // Cancel any on-going request.
+      while (!_.isEmpty(this._xhrRequests)) {
+        this._xhrRequests.pop().abort();
+      }
+    },
+
+    _startPolling: function(props) {
+      var url = this._getDataUrl(props);
+
+      var callback = function() {
+        this._fetchDataFromServer(url, this.receiveDataFromServer);
+      };
+
+      this._pollInterval = setInterval(callback.bind(this), props.pollInterval);
+    },
+
+    _clearPolling: function() {
+      clearInterval(this._pollInterval);
+      this._pollInterval = null;
+    },
+
+    _getDataUrl: function(props) {
+      return typeof(this.getDataUrl) === 'function' ?
+          this.getDataUrl(props) : props.dataUrl;
+    },
+
+    _fetchDataFromServer: function(url, onSuccess) {
+      this.setState({
+        isFetchingData: true,
+        dataError: null
+      });
+
+      var request,
+          onComplete,
+          onError;
+
+      onComplete = function() {
+        this._xhrRequests = _.without(this._xhrRequests, request);
+      };
+
+      onError = function(xhr, status, err) {
+        if (this._ignoreXhrRequestCallbacks) {
+          return;
+        }
+
+        this.setState({
+          isFetchingData: false,
+          dataError: {
+            url: url,
+            statusCode: xhr.status,
+            statusText: status,
+            message: err.toString()
+          }
+        });
+      };
+
+      request = $.ajax({
+        url: url,
+        // Even though not recommended, some $.ajaxSettings might default to POST
+        // requests. See http://api.jquery.com/jquery.ajaxsetup/
+        type: 'GET',
+        dataType: 'json',
+        complete: onComplete.bind(this),
+        success: onSuccess,
+        error: onError.bind(this)
+      });
+
+      this._xhrRequests.push(request);
+    },
+
+    _shouldWePoll: function(props) {
+      return props.pollInterval > 0;
+    }
+  };
 };

--- a/tests/data-fetch-mixin.js
+++ b/tests/data-fetch-mixin.js
@@ -15,7 +15,7 @@ describe('DataFetch mixin', function() {
     // doesn't detect a DOM
     $.ajax = sinon.stub().returns(ajaxStub);
 
-    fakeComponent = _.clone(DataFetch);
+    fakeComponent = _.clone(DataFetch());
 
     // Mock React API
     fakeComponent.setState = sinon.spy();

--- a/tests/data-fetch-mixin.js
+++ b/tests/data-fetch-mixin.js
@@ -3,8 +3,7 @@ var _ = require('lodash'),
     DataFetch = require('../src/data-fetch-mixin.js');
 
 describe('DataFetch mixin', function() {
-  var ajaxStub,
-      fakeComponent;
+  var ajaxStub, fakeComponent;
 
   beforeEach(function() {
     ajaxStub = {
@@ -15,283 +14,446 @@ describe('DataFetch mixin', function() {
     // doesn't detect a DOM
     $.ajax = sinon.stub().returns(ajaxStub);
 
-    fakeComponent = _.clone(DataFetch());
-
     // Mock React API
-    fakeComponent.setState = sinon.spy();
-    fakeComponent.props = {};
+    fakeComponent = {
+      setState: sinon.spy(),
+      props: {}
+    };
   });
 
-  it('should call $.ajax with dataUrl prop on mount', function() {
-    fakeComponent.props.dataUrl = 'my-api.json';
-
-    fakeComponent.componentWillMount();
-
-    expect($.ajax.args[0][0].url).to.equal('my-api.json');
-  });
-
-  it('should not call $.ajax when dataUrl is equal', function() {
-    fakeComponent.props.dataUrl = 'my-api.json';
-    fakeComponent.componentWillMount();
-
-    fakeComponent.componentWillReceiveProps({
-      dataUrl: 'my-api.json'
-    });
-
-    expect($.ajax.callCount).to.equal(1);
-  });
-
-  it('should call $.ajax when dataUrl prop changes', function() {
-    ajaxStub.abort = function() {};
-
-    fakeComponent.props.dataUrl = 'my-api.json';
-    fakeComponent.componentWillMount();
-
-    fakeComponent.componentWillReceiveProps({
-      dataUrl: 'my-api2.json'
-    });
-
-    expect($.ajax.lastCall.args[0].url).to.equal('my-api2.json');
-  });
-
-  it('should abort first call when changing dataUrl', function() {
-    ajaxStub.abort = sinon.spy();
-
-    fakeComponent.props.dataUrl = 'my-api.json';
-    fakeComponent.componentWillMount();
-
-    fakeComponent.componentWillReceiveProps({
-      dataUrl: 'my-api2.json'
-    });
-
-    expect(ajaxStub.abort).to.have.been.called;
-  });
-
-  it('should call $.ajax with getDataUrl method if defined', function() {
-    fakeComponent.getDataUrl = sinon.stub().returns('my-custom-api.json');
-
-    fakeComponent.componentWillMount();
-
-    expect(fakeComponent.getDataUrl).to.have.been.called;
-    expect($.ajax.args[0][0].url).to.equal('my-custom-api.json');
-  });
-
-  it('should call getDataUrl with props', function() {
-    fakeComponent.getDataUrl = sinon.spy();
-    fakeComponent.props.someProp = true;
-
-    fakeComponent.componentWillMount();
-
-    expect(fakeComponent.getDataUrl).to.have.been.calledWith({
-      someProp: true
-    });
-  });
-
-  it('should call $.ajax with receiveDataFromServer callback', function() {
-    fakeComponent.props.dataUrl = 'my-api.json';
-    fakeComponent.componentWillMount();
-
-    expect($.ajax.args[0][0].success)
-          .to.equal(fakeComponent.receiveDataFromServer);
-  });
-
-  it('should populate state.data with returned data', function() {
-    fakeComponent.receiveDataFromServer({
-      name: 'John Doe',
-      age: 42
-    });
-
-    var setStateArgs = fakeComponent.setState.args[0][0];
-    expect(setStateArgs.data.name).to.equal('John Doe');
-    expect(setStateArgs.data.age).to.equal(42);
-  });
-
-  it('should call $.ajax again when refreshData is called', function() {
-    ajaxStub.abort = function() {};
-
-    fakeComponent.props.dataUrl = 'my-api.json';
-    fakeComponent.componentWillMount();
-
-    fakeComponent.refreshData();
-
-    expect($.ajax.lastCall.args[0].url).to.equal('my-api.json');
-  });
-
-  it('should set isFetchingData true when mounting', function() {
-    fakeComponent.props.dataUrl = 'my-api.json';
-
-    fakeComponent.componentWillMount();
-
-    var setStateArgs = fakeComponent.setState.args[0][0];
-    expect(setStateArgs.isFetchingData).to.equal(true);
-  });
-
-  it('should set isFetchingData false when receiving data', function() {
-    fakeComponent.receiveDataFromServer({});
-
-    var setStateArgs = fakeComponent.setState.args[0][0];
-    expect(setStateArgs.isFetchingData).to.equal(false);
-  });
-
-  it('should set isFetchingData false if request errors', function() {
-    fakeComponent.props.dataUrl = 'my-api.json';
-
-    fakeComponent.componentWillMount();
-
-    var onError = $.ajax.args[0][0].error;
-    onError({}, 503, 'foobar');
-
-    var setStateArgs = fakeComponent.setState.lastCall.args[0];
-    expect(setStateArgs.isFetchingData).to.equal(false);
-  });
-
-  it('should not set state if request errors after unmount', function() {
-    ajaxStub.abort = function() {};
-
-    fakeComponent.props.dataUrl = 'my-api.json';
-
-    fakeComponent.componentWillMount();
-    fakeComponent.componentWillUnmount();
-
-    var prevCallCount = fakeComponent.setState.callCount;
-
-    var onError = $.ajax.args[0][0].error;
-    onError({}, 503, 'foobar');
-
-    expect(fakeComponent.setState.callCount).to.equal(prevCallCount);
-  });
-
-  it('should set isFetchingData to false in initial state', function() {
-    var initialState = fakeComponent.getInitialState();
-
-    expect(initialState.isFetchingData).to.equal(false);
-  });
-
-  it('should set dataError to null in initial state', function() {
-    var initialState = fakeComponent.getInitialState();
-
-    expect(initialState.dataError).to.equal(null);
-  });
-
-  describe('dataError set in this.state for failed requests', function() {
-    var url = 'www.foo.bar',
-        setStateArgs,
-        err = {toString: sinon.stub()},
-        xhrObj = {
-          status: 404,
-          statusText: 'Not found'
-        };
-
+  describe('same domain', function() {
     beforeEach(function() {
-      fakeComponent.props.dataUrl = url;
+      _.assign(fakeComponent, DataFetch());
+    });
+
+    it('should call $.ajax with dataUrl prop on mount', function() {
+      fakeComponent.props.dataUrl = 'my-api.json';
 
       fakeComponent.componentWillMount();
 
-      var onError = $.ajax.args[0][0].error;
-      onError(xhrObj, xhrObj.status, err);
-
-      setStateArgs = fakeComponent.setState.lastCall.args[0];
+      expect($.ajax.args[0][0].url).to.equal('my-api.json');
     });
 
-    afterEach(function() {
-      err.toString.reset();
-    });
-
-    it('should save the url of a failed request', function() {
-      expect(setStateArgs.dataError.url).to.equal(url);
-    });
-
-    it('should save the statusCode of a failed request', function() {
-      expect(setStateArgs.dataError.statusCode).to.equal(xhrObj.status);
-    });
-
-    it('should save the statusText of a failed request', function() {
-      expect(setStateArgs.dataError.statusText).to.equal(xhrObj.status);
-    });
-
-    it('should save the message of a failed request', function() {
-      expect(err.toString.callCount).to.equal(1);
-    });
-  });
-
-  describe('dataError should reset', function() {
-    beforeEach(function() {
-      fakeComponent.props.dataUrl = 'foo';
-
+    it('should not call $.ajax when dataUrl is equal', function() {
+      fakeComponent.props.dataUrl = 'my-api.json';
       fakeComponent.componentWillMount();
 
-      var onError = $.ajax.args[0][0].error;
-      ajaxStub.abort = function() {};
-      onError({}, 404, 'foobar');
-    });
-
-    it('should reset dataError when refreshing data', function() {
-      fakeComponent.refreshData();
-
-      var setStateArgs = fakeComponent.setState.lastCall.args[0];
-
-      expect(setStateArgs.dataError).to.equal(null);
-    });
-
-    it('should reset dataError when receiving new dataUrl', function() {
       fakeComponent.componentWillReceiveProps({
-        dataUrl: 'bar'
+        dataUrl: 'my-api.json'
       });
 
-      var setStateArgs = fakeComponent.setState.lastCall.args[0];
-
-      expect(setStateArgs.dataError).to.equal(null);
+      expect($.ajax.callCount).to.equal(1);
     });
-  });
 
-  describe('when stopping fetching', function() {
-    var nativeClearInterval = clearInterval;
+    it('should not send cross-domain cookies', function() {
+      fakeComponent.props.dataUrl = 'my-api.json';
 
-    beforeEach(function() {
+      fakeComponent.componentWillMount();
+
+      expect($.ajax).to.have.been.calledWith(
+          sinon.match.has('xhrFields',
+                          sinon.match.has('withCredentials', false)));
+    });
+
+    it('should call $.ajax when dataUrl prop changes', function() {
+      ajaxStub.abort = function() {};
+
+      fakeComponent.props.dataUrl = 'my-api.json';
+      fakeComponent.componentWillMount();
+
+      fakeComponent.componentWillReceiveProps({
+        dataUrl: 'my-api2.json'
+      });
+
+      expect($.ajax.lastCall.args[0].url).to.equal('my-api2.json');
+    });
+
+    it('should abort first call when changing dataUrl', function() {
       ajaxStub.abort = sinon.spy();
 
       fakeComponent.props.dataUrl = 'my-api.json';
       fakeComponent.componentWillMount();
 
-      fakeComponent.stopFetching();
-    });
-
-    it('should abort ajax call', function() {
-      expect(ajaxStub.abort).to.have.been.called;
-    });
-  });
-
-  describe('polling', function() {
-    var clock;
-
-    beforeEach(function() {
-      clock = sinon.useFakeTimers();
-    });
-
-    afterEach(function() {
-      clock.restore();
-    });
-
-    describe('wtih simple dataUrl', function() {
-      beforeEach(function() {
-        fakeComponent.props.dataUrl = 'my-api.json';
+      fakeComponent.componentWillReceiveProps({
+        dataUrl: 'my-api2.json'
       });
 
-      describe('when poll interval is given', function() {
+      expect(ajaxStub.abort).to.have.been.called;
+    });
+
+    it('should call $.ajax with getDataUrl method if defined', function() {
+      fakeComponent.getDataUrl = sinon.stub().returns('my-custom-api.json');
+
+      fakeComponent.componentWillMount();
+
+      expect(fakeComponent.getDataUrl).to.have.been.called;
+      expect($.ajax.args[0][0].url).to.equal('my-custom-api.json');
+    });
+
+    it('should call getDataUrl with props', function() {
+      fakeComponent.getDataUrl = sinon.spy();
+      fakeComponent.props.someProp = true;
+
+      fakeComponent.componentWillMount();
+
+      expect(fakeComponent.getDataUrl).to.have.been.calledWith({
+        someProp: true
+      });
+    });
+
+    it('should call $.ajax with receiveDataFromServer callback', function() {
+      fakeComponent.props.dataUrl = 'my-api.json';
+      fakeComponent.componentWillMount();
+
+      expect($.ajax.args[0][0].success)
+            .to.equal(fakeComponent.receiveDataFromServer);
+    });
+
+    it('should populate state.data with returned data', function() {
+      fakeComponent.receiveDataFromServer({
+        name: 'John Doe',
+        age: 42
+      });
+
+      var setStateArgs = fakeComponent.setState.args[0][0];
+      expect(setStateArgs.data.name).to.equal('John Doe');
+      expect(setStateArgs.data.age).to.equal(42);
+    });
+
+    it('should call $.ajax again when refreshData is called', function() {
+      ajaxStub.abort = function() {};
+
+      fakeComponent.props.dataUrl = 'my-api.json';
+      fakeComponent.componentWillMount();
+
+      fakeComponent.refreshData();
+
+      expect($.ajax.lastCall.args[0].url).to.equal('my-api.json');
+    });
+
+    it('should set isFetchingData true when mounting', function() {
+      fakeComponent.props.dataUrl = 'my-api.json';
+
+      fakeComponent.componentWillMount();
+
+      var setStateArgs = fakeComponent.setState.args[0][0];
+      expect(setStateArgs.isFetchingData).to.equal(true);
+    });
+
+    it('should set isFetchingData false when receiving data', function() {
+      fakeComponent.receiveDataFromServer({});
+
+      var setStateArgs = fakeComponent.setState.args[0][0];
+      expect(setStateArgs.isFetchingData).to.equal(false);
+    });
+
+    it('should set isFetchingData false if request errors', function() {
+      fakeComponent.props.dataUrl = 'my-api.json';
+
+      fakeComponent.componentWillMount();
+
+      var onError = $.ajax.args[0][0].error;
+      onError({}, 503, 'foobar');
+
+      var setStateArgs = fakeComponent.setState.lastCall.args[0];
+      expect(setStateArgs.isFetchingData).to.equal(false);
+    });
+
+    it('should not set state if request errors after unmount', function() {
+      ajaxStub.abort = function() {};
+
+      fakeComponent.props.dataUrl = 'my-api.json';
+
+      fakeComponent.componentWillMount();
+      fakeComponent.componentWillUnmount();
+
+      var prevCallCount = fakeComponent.setState.callCount;
+
+      var onError = $.ajax.args[0][0].error;
+      onError({}, 503, 'foobar');
+
+      expect(fakeComponent.setState.callCount).to.equal(prevCallCount);
+    });
+
+    it('should set isFetchingData to false in initial state', function() {
+      var initialState = fakeComponent.getInitialState();
+
+      expect(initialState.isFetchingData).to.equal(false);
+    });
+
+    it('should set dataError to null in initial state', function() {
+      var initialState = fakeComponent.getInitialState();
+
+      expect(initialState.dataError).to.equal(null);
+    });
+
+    describe('dataError set in this.state for failed requests', function() {
+      var url = 'www.foo.bar',
+          setStateArgs,
+          err = {toString: sinon.stub()},
+          xhrObj = {
+            status: 404,
+            statusText: 'Not found'
+          };
+
+      beforeEach(function() {
+        fakeComponent.props.dataUrl = url;
+
+        fakeComponent.componentWillMount();
+
+        var onError = $.ajax.args[0][0].error;
+        onError(xhrObj, xhrObj.status, err);
+
+        setStateArgs = fakeComponent.setState.lastCall.args[0];
+      });
+
+      afterEach(function() {
+        err.toString.reset();
+      });
+
+      it('should save the url of a failed request', function() {
+        expect(setStateArgs.dataError.url).to.equal(url);
+      });
+
+      it('should save the statusCode of a failed request', function() {
+        expect(setStateArgs.dataError.statusCode).to.equal(xhrObj.status);
+      });
+
+      it('should save the statusText of a failed request', function() {
+        expect(setStateArgs.dataError.statusText).to.equal(xhrObj.status);
+      });
+
+      it('should save the message of a failed request', function() {
+        expect(err.toString.callCount).to.equal(1);
+      });
+    });
+
+    describe('dataError should reset', function() {
+      beforeEach(function() {
+        fakeComponent.props.dataUrl = 'foo';
+
+        fakeComponent.componentWillMount();
+
+        var onError = $.ajax.args[0][0].error;
+        ajaxStub.abort = function() {};
+        onError({}, 404, 'foobar');
+      });
+
+      it('should reset dataError when refreshing data', function() {
+        fakeComponent.refreshData();
+
+        var setStateArgs = fakeComponent.setState.lastCall.args[0];
+
+        expect(setStateArgs.dataError).to.equal(null);
+      });
+
+      it('should reset dataError when receiving new dataUrl', function() {
+        fakeComponent.componentWillReceiveProps({
+          dataUrl: 'bar'
+        });
+
+        var setStateArgs = fakeComponent.setState.lastCall.args[0];
+
+        expect(setStateArgs.dataError).to.equal(null);
+      });
+    });
+
+    describe('when stopping fetching', function() {
+      var nativeClearInterval = clearInterval;
+
+      beforeEach(function() {
+        ajaxStub.abort = sinon.spy();
+
+        fakeComponent.props.dataUrl = 'my-api.json';
+        fakeComponent.componentWillMount();
+
+        fakeComponent.stopFetching();
+      });
+
+      it('should abort ajax call', function() {
+        expect(ajaxStub.abort).to.have.been.called;
+      });
+    });
+
+    describe('polling', function() {
+      var clock;
+
+      beforeEach(function() {
+        clock = sinon.useFakeTimers();
+      });
+
+      afterEach(function() {
+        clock.restore();
+      });
+
+      describe('wtih simple dataUrl', function() {
         beforeEach(function() {
+          fakeComponent.props.dataUrl = 'my-api.json';
+        });
+
+        describe('when poll interval is given', function() {
+          beforeEach(function() {
+            fakeComponent.props.pollInterval = _.random(1000, 5000);
+
+            fakeComponent.componentWillMount();
+          });
+
+          it('should start polling after mounting', function() {
+            $.ajax.reset();
+
+            var times = _.random(2, 5);
+
+            clock.tick(fakeComponent.props.pollInterval * times);
+
+            expect($.ajax).to.have.callCount(times);
+          });
+
+          it('should poll the right URL', function() {
+            $.ajax.reset();
+
+            var times = _.random(2, 5);
+
+            clock.tick(fakeComponent.props.pollInterval * times);
+
+            expect($.ajax).to.have.always.been.calledWith(
+                sinon.match.has('url', fakeComponent.props.dataUrl));
+          });
+
+          it('should stop polling when unmounting', function() {
+            $.ajax.reset();
+
+            fakeComponent.componentWillUnmount();
+
+            var times = _.random(2, 5);
+
+            clock.tick(fakeComponent.props.pollInterval * times);
+
+            expect($.ajax).to.not.have.been.called;
+          });
+
+          it('should stop polling when receiving pollInterval=0', function() {
+            $.ajax.reset();
+
+            var times = _.random(2, 5),
+                oldInterval = fakeComponent.props.pollInterval;
+
+            fakeComponent.componentWillReceiveProps(
+                _.merge({}, fakeComponent.props, {pollInterval: 0}));
+
+            clock.tick(oldInterval * times);
+
+            expect($.ajax).to.not.have.been.called;
+          });
+
+          it('should restart polling when receiving a new poll interval',
+             function() {
+            $.ajax.reset();
+
+            var times = _.random(2, 5),
+                oldInterval = fakeComponent.props.pollInterval,
+                newInterval = oldInterval * 2;
+
+            fakeComponent.componentWillReceiveProps(
+                _.merge({}, fakeComponent.props, {pollInterval: newInterval}));
+
+            clock.tick(newInterval * times);
+
+            expect($.ajax).to.have.callCount(times);
+          });
+
+          it('should stop polling when told to do so', function() {
+            $.ajax.reset();
+
+            fakeComponent.stopPolling();
+
+            clock.tick(fakeComponent.props.pollInterval);
+
+            expect($.ajax).to.not.have.been.called;
+          });
+
+          it('should start polling when told to resume', function() {
+            $.ajax.reset();
+            fakeComponent.stopPolling();
+            fakeComponent.resumePolling();
+
+            var times = _.random(2, 5);
+
+            clock.tick(fakeComponent.props.pollInterval * times);
+
+            expect($.ajax).to.have.callCount(times);
+          });
+
+          it('should only poll once if told to resume multiple times',
+             function() {
+            $.ajax.reset();
+            fakeComponent.stopPolling();
+
+            _.times(_.random(2, 5), fakeComponent.resumePolling, fakeComponent);
+
+            var times = _.random(2, 5);
+
+            clock.tick(fakeComponent.props.pollInterval * times);
+
+            expect($.ajax).to.have.callCount(times);
+          });
+
+          it('should poll the new URL when receiving one', function() {
+            $.ajax.reset();
+
+            var times = _.random(2, 5),
+                interval = _.random(1000, 5000),
+                oldUrl = fakeComponent.props.dataUrl,
+                newUrl = oldUrl + 'new';
+
+            fakeComponent.componentWillReceiveProps(
+                _.merge({}, fakeComponent.props, {dataUrl: newUrl}));
+
+            clock.tick(interval * times);
+
+            expect($.ajax).to.have.always.been.calledWith(
+                sinon.match.has('url', newUrl));
+          });
+        });
+
+        describe('when poll interval is not given', function() {
+          beforeEach(function() {
+            fakeComponent.props.pollInterval = 0;
+
+            fakeComponent.componentWillMount();
+          });
+
+          it('should not start polling after mounting', function() {
+            $.ajax.reset();
+
+            var times = _.random(2, 5);
+
+            clock.tick(fakeComponent.props.pollInterval * times);
+
+            expect($.ajax).to.not.have.been.called;
+          });
+
+          it('should start polling when receiving a poll interval', function() {
+            $.ajax.reset();
+
+            var times = _.random(2, 5),
+                interval = _.random(1000, 5000);
+
+            fakeComponent.componentWillReceiveProps(
+                _.merge({}, fakeComponent.props, {pollInterval: interval}));
+
+            clock.tick(interval * times);
+
+            expect($.ajax).to.have.callCount(times);
+          });
+        });
+      });
+
+      describe('with custom dataUrl', function() {
+        beforeEach(function() {
+          fakeComponent.getDataUrl = sinon.stub().returns('foobar.json');
           fakeComponent.props.pollInterval = _.random(1000, 5000);
 
           fakeComponent.componentWillMount();
-        });
-
-        it('should start polling after mounting', function() {
-          $.ajax.reset();
-
-          var times = _.random(2, 5);
-
-          clock.tick(fakeComponent.props.pollInterval * times);
-
-          expect($.ajax).to.have.callCount(times);
         });
 
         it('should poll the right URL', function() {
@@ -301,160 +463,29 @@ describe('DataFetch mixin', function() {
 
           clock.tick(fakeComponent.props.pollInterval * times);
 
-          expect($.ajax).to.have.always.been.calledWith(
-              sinon.match.has('url', fakeComponent.props.dataUrl));
-        });
-
-        it('should stop polling when unmounting', function() {
-          $.ajax.reset();
-
-          fakeComponent.componentWillUnmount();
-
-          var times = _.random(2, 5);
-
-          clock.tick(fakeComponent.props.pollInterval * times);
-
-          expect($.ajax).to.not.have.been.called;
-        });
-
-        it('should stop polling when receiving pollInterval=0', function() {
-          $.ajax.reset();
-
-          var times = _.random(2, 5),
-              oldInterval = fakeComponent.props.pollInterval;
-
-          fakeComponent.componentWillReceiveProps(
-              _.merge({}, fakeComponent.props, {pollInterval: 0}));
-
-          clock.tick(oldInterval * times);
-
-          expect($.ajax).to.not.have.been.called;
-        });
-
-        it('should restart polling when receiving a new poll interval',
-           function() {
-          $.ajax.reset();
-
-          var times = _.random(2, 5),
-              oldInterval = fakeComponent.props.pollInterval,
-              newInterval = oldInterval * 2;
-
-          fakeComponent.componentWillReceiveProps(
-              _.merge({}, fakeComponent.props, {pollInterval: newInterval}));
-
-          clock.tick(newInterval * times);
-
-          expect($.ajax).to.have.callCount(times);
-        });
-
-        it('should stop polling when told to do so', function() {
-          $.ajax.reset();
-
-          fakeComponent.stopPolling();
-
-          clock.tick(fakeComponent.props.pollInterval);
-
-          expect($.ajax).to.not.have.been.called;
-        });
-
-        it('should start polling when told to resume', function() {
-          $.ajax.reset();
-          fakeComponent.stopPolling();
-          fakeComponent.resumePolling();
-
-          var times = _.random(2, 5);
-
-          clock.tick(fakeComponent.props.pollInterval * times);
-
-          expect($.ajax).to.have.callCount(times);
-        });
-
-        it('should only poll once if told to resume multiple times',
-           function() {
-          $.ajax.reset();
-          fakeComponent.stopPolling();
-
-          _.times(_.random(2, 5), fakeComponent.resumePolling, fakeComponent);
-
-          var times = _.random(2, 5);
-
-          clock.tick(fakeComponent.props.pollInterval * times);
-
-          expect($.ajax).to.have.callCount(times);
-        });
-
-        it('should poll the new URL when receiving one', function() {
-          $.ajax.reset();
-
-          var times = _.random(2, 5),
-              interval = _.random(1000, 5000),
-              oldUrl = fakeComponent.props.dataUrl,
-              newUrl = oldUrl + 'new';
-
-          fakeComponent.componentWillReceiveProps(
-              _.merge({}, fakeComponent.props, {dataUrl: newUrl}));
-
-          clock.tick(interval * times);
+          expect(fakeComponent.getDataUrl).to.have.been.calledWith(
+              fakeComponent.props);
 
           expect($.ajax).to.have.always.been.calledWith(
-              sinon.match.has('url', newUrl));
-        });
-      });
-
-      describe('when poll interval is not given', function() {
-        beforeEach(function() {
-          fakeComponent.props.pollInterval = 0;
-
-          fakeComponent.componentWillMount();
-        });
-
-        it('should not start polling after mounting', function() {
-          $.ajax.reset();
-
-          var times = _.random(2, 5);
-
-          clock.tick(fakeComponent.props.pollInterval * times);
-
-          expect($.ajax).to.not.have.been.called;
-        });
-
-        it('should start polling when receiving a poll interval', function() {
-          $.ajax.reset();
-
-          var times = _.random(2, 5),
-              interval = _.random(1000, 5000);
-
-          fakeComponent.componentWillReceiveProps(
-              _.merge({}, fakeComponent.props, {pollInterval: interval}));
-
-          clock.tick(interval * times);
-
-          expect($.ajax).to.have.callCount(times);
+              sinon.match.has('url', 'foobar.json'));
         });
       });
     });
+  });
 
-    describe('with custom dataUrl', function() {
-      beforeEach(function() {
-        fakeComponent.getDataUrl = sinon.stub().returns('foobar.json');
-        fakeComponent.props.pollInterval = _.random(1000, 5000);
+  describe('cross domain', function() {
+    beforeEach(function() {
+      _.assign(fakeComponent, DataFetch({crossDomain: true}));
+    });
 
-        fakeComponent.componentWillMount();
-      });
+    it('should send cross-domain cookies', function() {
+      fakeComponent.props.dataUrl = 'my-api.json';
 
-      it('should poll the right URL', function() {
-        $.ajax.reset();
+      fakeComponent.componentWillMount();
 
-        var times = _.random(2, 5);
-
-        clock.tick(fakeComponent.props.pollInterval * times);
-
-        expect(fakeComponent.getDataUrl).to.have.been.calledWith(
-            fakeComponent.props);
-
-        expect($.ajax).to.have.always.been.calledWith(
-            sinon.match.has('url', 'foobar.json'));
-      });
+      expect($.ajax).to.have.been.calledWith(
+          sinon.match.has('xhrFields',
+                          sinon.match.has('withCredentials', true)));
     });
   });
 });


### PR DESCRIPTION
## Need

```gherkin
As a developer
I want to make cross-domain requests with authentication
So that I can separate my APIs for a cleaner SOA.
```


## Deliverables

- [ ] Making requests from domain `A.com` to `B.com` will send all the cookies set for `B.com`


## Solution

Make the `DataFetch` module export a constructor and in it accept an option that will set `withCredentials: true` on the requests.

```js
var DataFetch = require('react-data-fetch');

module.exports = React.createClass({
  mixins: [DataFetch({crossDomain: true})],

  ...
});
```

If you always want to make cross-domain requests you can simply create a wrapper over `DataFetch` that will return a new instance with `crossDomain: true`.

```js
// my-data-fetch.js
module.exports = require('react-data-fetch')({crossDomain: true});
```

Another solution would be to abstract the request mechanism and have the constructor accept a service that does the requests. You could then create a mixin instance with a service that does cross-domain requests.

Another option would be to make the module a singleton and have a local variable that activates the cross-domain logic and export a method for turning it on.

I think the first solution is the optimal one at this moment.


#### Prerequisites

- [withCredentials](http://devdocs.io/dom/xmlhttprequest#xmlhttprequest-withcredentials)
- [$.ajax](http://devdocs.io/jquery/jquery.ajax)


#### TODO

- [x] tests
  - [x] update existing tests to use the constructor
  - [x] building an instance with `crossDomain: true` will set `xhrFields.withCredentials: true` on the requests
  - [x] building an instance without it won't set it
- [ ] bump the major and release
