### PR TITLE
Error callback

### DIFF
--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -22,6 +22,9 @@ var _ = require('lodash'),
  * @param {Object} [options]
  * @param {Bool} [options.crossDomain=false] If `true`, the requests will
  *     contain the cookies set for the other domain.
+ * @param {Function} [onError] If given, it will be called whenever a request
+ *     fails. See http://devdocs.io/jquery/jquery.ajax for details on what
+ *     params will be passed.
  *
  * @returns {DataFetchMixin}
  */
@@ -29,7 +32,8 @@ module.exports = function(options) {
   options = options || {};
 
   _.defaults(options, {
-    crossDomain: false
+    crossDomain: false,
+    onError: function() {}
   });
 
   return {
@@ -197,6 +201,8 @@ module.exports = function(options) {
             message: err.toString()
           }
         });
+
+        options.onError.apply(this, arguments);
       };
 
       request = $.ajax({

--- a/tests/data-fetch-mixin.js
+++ b/tests/data-fetch-mixin.js
@@ -488,4 +488,31 @@ describe('DataFetch mixin', function() {
                           sinon.match.has('withCredentials', true)));
     });
   });
+
+  describe('error callback', function() {
+    var errorCallback;
+
+    beforeEach(function() {
+      errorCallback = sinon.spy();
+
+      _.assign(fakeComponent, DataFetch({onError: errorCallback}));
+    });
+
+    it('should call the error callback when a request errors', function() {
+      fakeComponent.props.dataUrl = 'my-api.json';
+
+      fakeComponent.componentWillMount();
+
+      var onError = $.ajax.args[0][0].error;
+
+      var xhrObject = {foo: 'bar'},
+          statusCode = 42,
+          errMessage = 'foobared';
+
+      onError(xhrObject, statusCode, errMessage);
+
+      expect(errorCallback).to.have.been.calledWith(
+          xhrObject, statusCode, errMessage);
+    });
+  });
 });


### PR DESCRIPTION
## Need

```gherkin
As a developer
I want a hook for when errors occur
So that I can act upon them.
```


## Deliverables

- [x] When a request errors out a given callback is called.


## Solution

Accept a callback in the constructor and call it when the request errors. We can probably get rid of [state.dataError](https://github.com/skidding/react-data-fetch/blob/032477bca38bf604ab30e22f2dda80f9bdb247ec/src/data-fetch-mixin.js#L193-L198) and use the callback exclusively.


#### TODO

- [x] tests
  - [x] set the callback in the constructor as `options.onError`
  - [x] make a request fail and check that the callback has been called
