### PR TITLE
Add response to state onError callback

### DIFF
--- a/src/data-fetch-mixin.js
+++ b/src/data-fetch-mixin.js
@@ -198,7 +198,8 @@ module.exports = function(options) {
             url: url,
             statusCode: xhr.status,
             statusText: status,
-            message: err.toString()
+            message: err.toString(),
+            response: xhr.responseJSON
           }
         });
 

--- a/tests/data-fetch-mixin.js
+++ b/tests/data-fetch-mixin.js
@@ -193,7 +193,8 @@ describe('DataFetch mixin', function() {
           err = {toString: sinon.stub()},
           xhrObj = {
             status: 404,
-            statusText: 'Not found'
+            statusText: 'Not found',
+            responseText: '{"foo": "bar"}'
           };
 
       beforeEach(function() {
@@ -225,6 +226,10 @@ describe('DataFetch mixin', function() {
 
       it('should save the message of a failed request', function() {
         expect(err.toString.callCount).to.equal(1);
+      });
+
+      it('should save the response of a failed request', function() {
+        expect(setStateArgs.response).to.equal(xhrObj.responseJSON);
       });
     });
 


### PR DESCRIPTION
## Need

```gherkin
As a developer
I want to see backend response when errors occur
So that I can act upon them.
```

## Deliverables
The mixin will load into state.dataError an additional field with the server response called `response`.

## Solution
- in the `_fetchDataFromServer` `onError` callback we will add an aditional field `response` that will take the `xhr.responseJSON` value
```js
this.setState({
  isFetchingData: false,
  dataError: {
    url: url,
    statusCode: xhr.status,
    statusText: status,
    message: err.toString(),
    response: xhr.responseJSON
  }
});
```